### PR TITLE
argv.slice(2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function main() {
   var exe = eslintNearFile(relativeFrom)
   if (exe) {
     // shell.echo("using eslint at " + exe)
-    kexec(exe, process.argv)
+    kexec(exe, process.argv.slice(2))
   } else {
     shell.echo('eslint not found')
     process.exit(1)


### PR DESCRIPTION
I'm not exactly sure why, but eslint-project-relative will only work in Flycheck within Emacs when I slice argv like this. It used to work without slicing, but perhaps I updated my OS, node, Emacs, or flycheck and something has changed.

When I execute `eslint-project-relative  .` from Terminal, I get:
```
[ '/Users/mstorus/.nvm/versions/node/v6.9.4/bin/node',
  '/Users/mstorus/.nvm/versions/node/v6.9.4/bin/eslint-project-relative',
  '.' ]
```

My setup:
```
Mac OS 10.12.2

node --version && npm --version && emacs --version
v6.9.4
3.10.10
GNU Emacs 25.1.1
Flycheck version: 31snapshot
```

After making this modification, Flycheck works again.

@justjake @aifreedom